### PR TITLE
make Result immutable so that it doesn't allocate

### DIFF
--- a/src/ResultTypes.jl
+++ b/src/ResultTypes.jl
@@ -2,7 +2,7 @@ module ResultTypes
 
 export Result, ErrorResult, unwrap, unwrap_error, iserror
 
-type Result{T, E<:Exception}
+immutable Result{T, E<:Exception}
     result::Nullable{T}
     error::Nullable{E}
 end


### PR DESCRIPTION
(cool talk at JuliaCon today!)

Changing Result from a `type` to an `immutable` makes everything faster and prevents allocation (in your benchmark). Specifically, the benchmark from the Readme runs about 2X faster and allocates 0 bytes with this change. As far as I can tell, this is a reasonable thing to do, since I can't think of a situation where a Result should be mutated after creation. 