### PR TITLE
Added a no-op convert method

### DIFF
--- a/src/ResultTypes.jl
+++ b/src/ResultTypes.jl
@@ -40,6 +40,12 @@ function unwrap_error(r::Result{T, E})::E where {T, E}
     end
 end
 
+# To avoid ambiguity errors. For example, when returning `Result` types from a map function
+# we end up doing a `convert(::Type{ResultTypes.Result{S,E}}, ::ResultTypes.Result{S,E})`.
+function Base.convert(::Type{Result{S, E}}, r::Result{S, E}) where {S, E}
+    return r
+end
+
 function Base.convert(::Type{T}, r::Result{S, E})::T where {T, S, E}
     unwrap(r)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,16 @@ end
         @test unwrap_error(x) == DivideError()
         @test isa(x, Result{Int, DivideError})
     end
+
+    @testset "Result to Result" begin
+        r = Result{Int, DivideError}(DivideError())
+        x = convert(Result{Int, DivideError}, r)
+        @test r == x
+
+        r = Result{Int, ErrorException}(2)
+        x = convert(Result{Int, ErrorException}, r)
+        @test r == x
+    end
 end
 
 @testset "Return" begin


### PR DESCRIPTION
 This is to avoid ambiguity errors when converting a `Result` to a `Result` (e.g., `map` over a function that returns `Result` types).