### PR TITLE
Changes for major release

### DIFF
--- a/src/ResultTypes.jl
+++ b/src/ResultTypes.jl
@@ -5,7 +5,7 @@ module ResultTypes
 using Nullables
 import Base: convert
 
-export Result, ErrorResult, unwrap, unwrap_error, iserror
+export Result, ErrorResult, unwrap, unwrap_error
 
 struct Result{T, E <: Exception}
     result::Nullable{T}

--- a/src/ResultTypes.jl
+++ b/src/ResultTypes.jl
@@ -113,8 +113,6 @@ function Base.convert(::Type{Result{S, E}}, r::Result) where {S, E <: Exception}
     return promote_type(Result{S, E}, typeof(r))(r.result, r.error)
 end
 
-@deprecate convert(t::Type, r::Result) unwrap(t, r)
-
 function Base.convert(::Type{Result{S, E}}, x::T) where {T, S, E <: Exception}
     return Result{S, E}(Nullable{S}(convert(S, x)), Nullable{E}())
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,10 +75,6 @@ end
 @testset "Convert" begin
     @testset "From Result" begin
         x = Result(2)
-        @test convert(Int, x) === 2  # deprecated
-        @test convert(Float64, x) === 2.0  # deprecated
-        @test_throws MethodError convert(String, x)  # deprecated
-
         @test unwrap(Int, x) === 2
         @test unwrap(Float64, x) === 2.0
         @test_throws MethodError unwrap(String, x)
@@ -86,7 +82,6 @@ end
 
     @testset "From ErrorResult" begin
         x = ErrorResult(Int, "Foo")
-        @test_throws ErrorException convert(Int, x)  # deprecated
         @test_throws ErrorException unwrap(Int, x)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Nullables
         x = Result(2)
         @test unwrap(x) === 2
         @test_throws ErrorException unwrap_error(x)
-        @test iserror(x) === false
+        @test ResultTypes.iserror(x) === false
         @test x isa Result{Int, Exception}
 
         # on unwrapped already
@@ -21,7 +21,7 @@ using Nullables
         x = Result(2, DivideError)
         @test unwrap(x) === 2
         @test_throws ErrorException unwrap_error(x)
-        @test iserror(x) === false
+        @test ResultTypes.iserror(x) === false
         @test x isa Result{Int, DivideError}
     end
 
@@ -39,12 +39,12 @@ end
         e = unwrap_error(x)
         @test isa(e, ErrorException)
         @test e.msg == "Basic Error"
-        @test iserror(x) === true
+        @test ResultTypes.iserror(x) === true
 
         # directly on exceptions
-        @test iserror(e)
+        @test ResultTypes.iserror(e)
         @test unwrap_error(e) === e
-        @test !iserror(2)
+        @test !ResultTypes.iserror(2)
     end
 
     @testset "Empty error" begin
@@ -52,14 +52,14 @@ end
         @test_throws ErrorException unwrap(x)
         e = unwrap_error(x)
         @test isa(e, ErrorException)
-        @test iserror(x) === true
+        @test ResultTypes.iserror(x) === true
         @test x isa Result{Int, ErrorException}
 
         x = ErrorResult()
         @test_throws ErrorException unwrap(x)
         e = unwrap_error(x)
         @test isa(e, ErrorException)
-        @test iserror(x) === true
+        @test ResultTypes.iserror(x) === true
         @test x isa Result{Any, ErrorException}
     end
 
@@ -67,7 +67,7 @@ end
         x = ErrorResult(Int, DivideError())
         @test_throws DivideError unwrap(x)
         @test isa(unwrap_error(x), DivideError)
-        @test iserror(x) === true
+        @test ResultTypes.iserror(x) === true
         @test x isa Result{Int, DivideError}
     end
 end


### PR DESCRIPTION
Unexport `iserror` (likely to be a common function name) and remove deprecated method.