### PR TITLE
Updates for Julia 0.7 and 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
   - 0.7
   - 1.0
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,1 @@
-julia 0.6
-Nullables 0.0.3
-Compat 0.33
+julia 0.7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using ResultTypes
-using Compat.Test
-using Nullables
+using Test
 
 @testset "ResultTypes" begin
 
@@ -26,7 +25,7 @@ using Nullables
     end
 
     @testset "Malformed result" begin
-        x = Result(Nullable{Int}(), Nullable{DivideError}())
+        x = Result{Int, Exception}(nothing, nothing)
         @test_throws ErrorException unwrap(x)
         @test_throws ErrorException unwrap_error(x)
     end


### PR DESCRIPTION
Summary of changes:
* Add 0.7 and 1.0 to the Travis matrix
* Use the default Travis script
* Remove dependency on Nullables
* Use `Union`s instead of `Nullable`s to represent optional values