### PR TITLE
Add at-try(x) macro

### DIFF
--- a/docs/src/pages/api.md
+++ b/docs/src/pages/api.md
@@ -14,3 +14,9 @@ unwrap
 unwrap_error
 ResultTypes.iserror
 ```
+
+## Macros
+
+```@docs
+@try
+```


### PR DESCRIPTION
* Immediately returns an error `x` is an error, otherwise unwraps `x`

This mimics the behavior of the macro of the same name in Rust.  

Rust has actually moved away from this macro, now adding `?` to the end of `Result` types instead.  That option isn't available to Julia (unless, perhaps, Julia moves towards using `ResultTypes` by default.)

I really wanted to call this `@?`, but question marks are not valid identifiers (they're syntax).  I also tried `@/` (a `?` without pressing shift, on US keyboards at least).  But that looked funny, so I went with precedence.

One other Rust-like behavior that this assumes is that exceptions higher in the stack will be converted to different exceptions as the stack unwinds.  This is not common in Julia code (because exceptions are usually thrown, so there's little need to `convert` them).  An additional `Result` `convert` method was added to make this easier, but users will still need to add `convert` methods for converting between their own exception types.

Example from the tests:

```julia
using ResultTypes

struct BarError <: Exception end
struct FooError <: Exception end
Base.convert(::Type{FooError}, ::BarError) = FooError()

function isbar(x)::Result{Bool, BarError}
    x == "foo" && return BarError()
    return x == "bar"
end

function foo(x)::Result{Int, FooError}
    bar = @try isbar(x)
    return bar ? 42 : 13
end

foobar = foo("bar") # unwrap(foobar) === 42
foofoo = foo("foo") # unwrap_error(foofoo) === FooError()
football = foo("tball") # unwrap(football) === 13
```
