### PR TITLE
Add Ref-like broadcast

### DIFF
--- a/src/ResultTypes.jl
+++ b/src/ResultTypes.jl
@@ -7,6 +7,8 @@ struct Result{T, E <: Exception}
     error::Union{E, Nothing}
 end
 
+Base.broadcastable(r::Result) = Ref(r)
+
 """
     Result(val::T, exception_type::Type{E}=Exception) -> Result{T, E}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ struct FooError <: Exception end
         # on unwrapped already
         y = unwrap(x)
         @test unwrap(y) === y
+
+        # can be broadcasted over
+        x = Result(4)
+        @test unwrap.(x) == 4
     end
 
     @testset "Result with error type" begin


### PR DESCRIPTION
Currently, broadcasting over e.g. a `Vector{<:Result}` complains about `Base.length(::Result)` not defined, as `Result` is assumed to be an iterator type. Since `Result` is not an iterator, I believe it would make sense to adapt `Base.broadcastable` so that we can broadcast on `Result` containers.

I don't think this requires any tests, but I can add one if you prefer.

EDIT: my bad, broadcasting on a vector containing `Result`s is actually fine. The problem happens when broadcasting with a `Result` not `Ref`ed. I still believe this to be nice to have, though.