### PR TITLE
avoid specializing `convert` for `Any` result types

### DIFF
--- a/src/ResultTypes.jl
+++ b/src/ResultTypes.jl
@@ -113,8 +113,16 @@ function Base.convert(::Type{Result{S, E}}, r::Result) where {S, E <: Exception}
     return promote_type(Result{S, E}, typeof(r))(r.result, r.error)
 end
 
+function Base.convert(::Type{Result{Any, E}}, r::Result) where {E <: Exception}
+    return promote_type(Result{Any, E}, typeof(r))(r.result, r.error)
+end
+
 function Base.convert(::Type{Result{S, E}}, x::T) where {T, S, E <: Exception}
     return Result{S, E}(Some(convert(S, x)), nothing)
+end
+
+function Base.convert(::Type{Result{Any, E}}, @nospecialize(x)) where {E <: Exception}
+    return Result{Any, E}(Some{Any}(x), nothing)
 end
 
 function Base.convert(::Type{Result{T, E}}, e::E) where {T, E <: Exception}
@@ -123,6 +131,10 @@ end
 
 function Base.convert(::Type{Result{T, E}}, e::E2) where {T, E <: Exception, E2 <: Exception}
     return Result{T,E}(nothing, convert(E, e))
+end
+
+function Base.convert(::Type{Result{Any, E}}, e::E2) where {E <: Exception, E2 <: Exception}
+    return Result{Any,E}(nothing, convert(E, e))
 end
 
 function Base.show(io::IO, r::Result{T, E}) where {T, E <: Exception}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,6 +146,15 @@ end
 
         @test isempty(ambs)
     end
+
+    @testset "Specializations" begin
+        AnyRes = Result{Any, Exception}
+        struct MyT end
+
+        convert(AnyRes, MyT())
+        method = only(methods(convert, Tuple{Type{AnyRes}, MyT}))
+        @test only(filter(!isnothing, collect(method.specializations))).specTypes == Tuple{typeof(convert), Type{AnyRes}, Any}
+    end
 end
 
 @testset "Return" begin


### PR DESCRIPTION
Specializing `convert(Result{Any, E}, x)` for every type of `x` can incur substantial compilation overhead (not only on `convert` but also on `Some`). This change avoids specializing in case of explicit `Any` result type.

This is analogous to Julia Base where we have
```
convert(::Type{Any}, Core.@nospecialize x) = x
```
to avoid excessive specialization.